### PR TITLE
Figuring out Linker Errors 

### DIFF
--- a/rocks/src/CMakeLists.txt
+++ b/rocks/src/CMakeLists.txt
@@ -9,15 +9,13 @@ set_target_properties(rocks PROPERTIES
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
 
-find_library(ZSTD_LIBRARY NAMES zstd PATHS /lib/x86_64-linux-gnu)
-find_library(LZ4_LIBRARY NAMES lz4 PATHS /lib/x86_64-linux-gnu)
-find_library(SNAPPY_LIBRARY NAMES snappy PATHS /lib/x86_64-linux-gnu)
+find_library(ZSTD_LIBRARIES NAMES zstd PATHS /lib/x86_64-linux-gnu)
+find_library(LZ4_LIBRARIES NAMES lz4 PATHS /lib/x86_64-linux-gnu)
+find_library(SNAPPY_LIBRARIES NAMES snappy PATHS /lib/x86_64-linux-gnu)
 
 # Include directories for header files
 target_include_directories(rocks PRIVATE
     ${PROJECT_SOURCE_DIR}/rocksdb/include
-    ${ZLIB_INCLUDE_DIRS}
-    ${BZIP2_INCLUDE_DIR}
 )
 
 # Link the precompiled static library
@@ -29,8 +27,8 @@ target_link_libraries(rocks
     rocksdb
     ${ZLIB_LIBRARIES}
     ${BZIP2_LIBRARIES}
-    ${ZSTD_LIBRARY}
-    ${LZ4_LIBRARY}
-    ${SNAPPY_LIBRARY}
+    ${ZSTD_LIBRARIES}
+    ${LZ4_LIBRARIES}
+    ${SNAPPY_LIBRARIES}
 )
 

--- a/rocks/src/CMakeLists.txt
+++ b/rocks/src/CMakeLists.txt
@@ -5,20 +5,32 @@ set_target_properties(rocks PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
-
 # Find the required libraries
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
 
-# Include directories for header files if there are any
-include_directories(${PROJECT_SOURCE_DIR}/rocksdb/include)
-include_directories(${ZLIB_INCLUDE_DIRS})
-include_directories(${BZIP2_INCLUDE_DIR})
+find_library(ZSTD_LIBRARY NAMES zstd PATHS /lib/x86_64-linux-gnu)
+find_library(LZ4_LIBRARY NAMES lz4 PATHS /lib/x86_64-linux-gnu)
+find_library(SNAPPY_LIBRARY NAMES snappy PATHS /lib/x86_64-linux-gnu)
+
+# Include directories for header files
+target_include_directories(rocks PRIVATE
+    ${PROJECT_SOURCE_DIR}/rocksdb/include
+    ${ZLIB_INCLUDE_DIRS}
+    ${BZIP2_INCLUDE_DIR}
+)
 
 # Link the precompiled static library
 add_library(rocksdb STATIC IMPORTED)
 set_target_properties(rocksdb PROPERTIES IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/rocksdb/librocksdb.a)
 
 # Link the static library to the executable
-target_link_libraries(rocks rocksdb ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES})
+target_link_libraries(rocks
+    rocksdb
+    ${ZLIB_LIBRARIES}
+    ${BZIP2_LIBRARIES}
+    ${ZSTD_LIBRARY}
+    ${LZ4_LIBRARY}
+    ${SNAPPY_LIBRARY}
+)
 


### PR DESCRIPTION
Everything was working in the morning and then I decided to test out an Ubuntu Desktop install (going through all the same installation processes I lay out in my [gists](gists.github.com/hitorilabs)). However, it seems that the installed libraries ended up in non-standard places where it can't get found. 

useful for finding list of known libraries:
```
ldconfig -p | rg <pkg_keywords>
```

It seems like regularly you should be able to `find_package` with cmake and get all of the paths to libraries without any additional effort, but that wasn't the case for `zstd lz4 snappy`

Anyways, you live and you learn - I feel a little better about actually reading error messages and debugging things on my own now.